### PR TITLE
fix #10: Set proper plugin version automatically by build file

### DIFF
--- a/project/dexter-core/src/java/com/samsung/sec/dexter/core/plugin/PluginVersion.java
+++ b/project/dexter-core/src/java/com/samsung/sec/dexter/core/plugin/PluginVersion.java
@@ -41,6 +41,18 @@ public class PluginVersion {
 	
 	final static Logger logger = Logger.getLogger(PluginVersion.class);
 	
+	/**
+	 * Create new PluginVersion based on implementation version of given plugin class.
+	 * 
+	 * @param clazz the class of the plugin
+	 * 
+	 * @return new PluginVersion based on 'Implementation-Version' property in a manifest file
+	 */
+	public static PluginVersion fromImplementationVersion(Class<?> clazz) {
+		String version = clazz.getPackage().getImplementationVersion();
+		return new PluginVersion(version);
+	}
+	
 	public PluginVersion(final int major, final int minor, final int patch){
 		this.major = major;
 		this.minor = minor;

--- a/project/dexter-cppcheck/build-jar-without-lib.xml
+++ b/project/dexter-cppcheck/build-jar-without-lib.xml
@@ -17,6 +17,7 @@
 		<jar destfile="${dist}/dexter-cppcheck_${version}.jar" filesetmanifest="mergewithoutmain">
 			<manifest>
 				<attribute name="Class-Path" value="."/>
+				<attribute name="Implementation-Version" value="${version}"/>
 			</manifest>
 			
 			<fileset dir="bin"/>

--- a/project/dexter-cppcheck/src/java/com/samsung/sec/dexter/cppcheck/plugin/CppcheckDexterPlugin.java
+++ b/project/dexter-cppcheck/src/java/com/samsung/sec/dexter/cppcheck/plugin/CppcheckDexterPlugin.java
@@ -51,7 +51,7 @@ import com.samsung.sec.dexter.core.util.DexterUtil;
 @PluginImplementation
 public class CppcheckDexterPlugin implements IDexterPlugin {
 	public final static String PLUGIN_NAME = "cppcheck";
-	public final static PluginVersion version = new PluginVersion(0, 9, 2);
+	public final static PluginVersion version = PluginVersion.fromImplementationVersion(CppcheckDexterPlugin.class);
 	private PluginDescription pluginDescription;
 	private CppcheckWrapper cppcheck = new CppcheckWrapper();
 	private final static Logger logger = Logger.getLogger(CppcheckWrapper.class);

--- a/project/dexter-findbugs/build-jar-without-lib.xml
+++ b/project/dexter-findbugs/build-jar-without-lib.xml
@@ -14,6 +14,7 @@
 		<jar destfile="${dist}/dexter-findbugs_${version}.jar" filesetmanifest="mergewithoutmain">
 			<manifest>
 				<attribute name="Class-Path" value="."/>
+				<attribute name="Implementation-Version" value="${version}"/>
 			</manifest>
 			
 			<fileset dir="bin"/>

--- a/project/dexter-findbugs/src/java/com/samsung/sec/dexter/findbugs/plugin/FindbugsDexterPlugin.java
+++ b/project/dexter-findbugs/src/java/com/samsung/sec/dexter/findbugs/plugin/FindbugsDexterPlugin.java
@@ -62,7 +62,7 @@ public class FindbugsDexterPlugin implements IDexterPlugin {
     	if(this.pluginDescription == null)
     	{
     		this.pluginDescription = new PluginDescription(PLUGIN_NAME, PLUGIN_NAME, 
-    				new PluginVersion(0,9,2), 
+    				PluginVersion.fromImplementationVersion(FindbugsDexterPlugin.class),
     				DexterConfig.LANGUAGE.JAVA, "Dexter plug-in for FindBugs");
     	}
 	    return this.pluginDescription;

--- a/project/dexter-opensource/build-jar-without-lib.xml
+++ b/project/dexter-opensource/build-jar-without-lib.xml
@@ -14,6 +14,7 @@
 		<jar destfile="${dist}/dexter-opensource_${version}.jar" filesetmanifest="mergewithoutmain">
 			<manifest>
 				<attribute name="Class-Path" value="."/>
+				<attribute name="Implementation-Version" value="${version}"/>
 			</manifest>
 			
 			<fileset dir="bin"/>

--- a/project/dexter-opensource/src/java/com/samsung/sec/dexter/opensource/plugin/DexterOpensourcePlugin.java
+++ b/project/dexter-opensource/src/java/com/samsung/sec/dexter/opensource/plugin/DexterOpensourcePlugin.java
@@ -88,7 +88,7 @@ public class DexterOpensourcePlugin implements IDexterPlugin {
 	@Override
 	public PluginDescription getDexterPluginDescription() {
 		return new PluginDescription("Samsung Electroincs", PLUGIN_NAME, 
-				new  PluginVersion(0, 9, 2), 
+				PluginVersion.fromImplementationVersion(DexterOpensourcePlugin.class), 
 				DexterConfig.LANGUAGE.ALL, 
 				"");
 	}

--- a/project/dexter-vd-cpp/build-jar-without-lib.xml
+++ b/project/dexter-vd-cpp/build-jar-without-lib.xml
@@ -15,6 +15,7 @@
 			<manifest>
 				<!--attribute name="Main-Class" value="com.samsung.sec.dexter.findbugs.plugin.FindBugsWrapper"/-->
 				<attribute name="Class-Path" value="."/>
+				<attribute name="Implementation-Version" value="${version}"/>
 			</manifest>
 			
 			<fileset dir="bin"/>

--- a/project/dexter-vd-cpp/src/java/com/samsung/sec/dexter/vdcpp/plugin/DexterVdCppPlugin.java
+++ b/project/dexter-vd-cpp/src/java/com/samsung/sec/dexter/vdcpp/plugin/DexterVdCppPlugin.java
@@ -135,7 +135,7 @@ public class DexterVdCppPlugin implements IDexterPlugin {
 	@Override
 	public PluginDescription getDexterPluginDescription() {
 		return new PluginDescription("Samsung Electroincs", PLUGIN_NAME, 
-				new  PluginVersion(0, 9, 2), 
+				PluginVersion.fromImplementationVersion(DexterVdCppPlugin.class),
 				DexterConfig.LANGUAGE.CPP, 
 				"");
 	}


### PR DESCRIPTION
I (hopefully) fixed issue #10 . 
Plugin version is now configured by "Implementation-Version" parameter in manifest file. 
"Implementation-Version" is set by Ant build file, so there is no need to keep these values in code. 