### PR TITLE
Fixed incorrect error handling in mailing.js

### DIFF
--- a/project/dexter-monitor/util/mailing.js
+++ b/project/dexter-monitor/util/mailing.js
@@ -86,9 +86,10 @@ function sendEmailByAPI(emailParameters, callback){
         email.apiUrl,
         { form: mailOptions },
         function (error, response /*, body*/){
-            handleEmailingErrorWithCallback(error, callback);
-
-            if(response.statusCode === 200){
+	    if(error){
+	        handleEmailingErrorWithCallback(error, callback);
+ 	    }
+	    else if(response.statusCode === 200){
                 handleEmailingSuccessWithCallback(emailParameters.title, callback);
             } else {
                 log.error(response)


### PR DESCRIPTION
In case of error, method `handleEmailingErrorWithCallback()` was called, but it didn't stop executing the rest of the function, so the callback was called for the second time. 