### PR TITLE
[monitor] Add timeout option to request-promise call

### DIFF
--- a/project/dexter-monitor/routes/defect.js
+++ b/project/dexter-monitor/routes/defect.js
@@ -117,7 +117,7 @@ exports.getMaxWeek = function(req, res) {
 exports.getDefectCountByProjectName = function(req, res) {
     const projectServer = _.find(server.getServerListInternal(), {'projectName': req.params.projectName});
     const defectCountUrl = `http://${projectServer.hostIP}:${projectServer.portNumber}/api/v2/defect-count`;
-    rp(defectCountUrl)
+    rp({uri: defectCountUrl, timeout: 2000})
         .then((data) => {
             const parsedData = JSON.parse('' + data);
             res.send({status:'ok', values: parsedData.values});
@@ -139,7 +139,7 @@ exports.saveSnapshot = function() {
         let userCount = 0;
 
         promises.push(new Promise((resolve, reject) => {
-            rp(defectCountUrl)
+            rp({uri: defectCountUrl, timeout: 2000})
                 .then((data) => {
                     defectValues = JSON.parse('' + data).values;
                     resolve();
@@ -150,7 +150,7 @@ exports.saveSnapshot = function() {
                 });
         }));
         promises.push(new Promise((resolve, reject) => {
-            rp(userCountUrl)
+            rp({uri: userCountUrl, timeout: 2000})
                 .then((data) => {
                     userCount = JSON.parse('' + data).value;
                     resolve();

--- a/project/dexter-monitor/routes/project.js
+++ b/project/dexter-monitor/routes/project.js
@@ -120,7 +120,7 @@ function loadDefectStatusSummary(resolve, summary) {
 
     Promise.map(activeServerList, (server) => {
         const defectCountUrl = `http://${server.hostIP}:${server.portNumber}/api/v2/defect-count`;
-        return rp(defectCountUrl)
+        return rp({uri: defectCountUrl, timeout: 2000})
             .then((data) => {
                 server.defectValues = JSON.parse('' + data).values;
             })

--- a/project/dexter-monitor/routes/user.js
+++ b/project/dexter-monitor/routes/user.js
@@ -45,7 +45,7 @@ exports.getAll = function(req, res) {
     Promise.map(activeServerList, (server) => {
         promises.push(new Promise((resolve) => {
             const userListUrl = `http://${server.hostIP}:${server.portNumber}/api/v2/user-list`;
-            rp(userListUrl)
+            rp({uri: userListUrl, timeout: 2000})
                 .then((data) => {
                     const rows = JSON.parse('' + data).rows;
                     if (rows) {
@@ -81,7 +81,7 @@ function processReturnedData(data) {
 }
 
 function loadUserInfo(userId, userInfoUrl, userInfoList) {
-    return rp(userInfoUrl + userId)
+    return rp({uri: userInfoUrl + userId, timeout: 2000})
         .then((data) => {
             data = processReturnedData(data);
             if (!data || !validateUserInfoJson(data, userId)) {
@@ -136,7 +136,7 @@ function validateUserInfoJson(data, userid) {
 exports.getUserCountByProjectName = function(req, res) {
     const projectServer = _.find(server.getServerListInternal(), {'projectName': req.params.projectName});
     const userCountUrl = `http://${projectServer.hostIP}:${projectServer.portNumber}/api/v2/user-count`;
-    rp(userCountUrl)
+    rp({uri: userCountUrl, timeout: 2000})
         .then((data) => {
             const parsedData = JSON.parse('' + data);
             res.send({status:'ok', value: parsedData.value});
@@ -167,7 +167,7 @@ function loadUserList() {
     Promise.map(activeServerList, (server) => {
         promises.push(new Promise((resolve) => {
             const userListUrl = `http://${server.hostIP}:${server.portNumber}/api/v2/user-list`;
-            rp(userListUrl)
+            rp({uri: userListUrl, timeout: 2000})
                 .then((data) => {
                     const rows = JSON.parse('' + data).rows;
                     if (rows) {


### PR DESCRIPTION
 All fields in Overview page are empty when some servers are busy.
 To resolve the problem, timout option should be added.