### PR TITLE
[monitor] Add API for server list update

### DIFF
--- a/project/dexter-monitor/app.js
+++ b/project/dexter-monitor/app.js
@@ -147,6 +147,7 @@ function setWebApis(){
     app.get('/api/v1/server', server.getServerList);
     app.get('/api/v1/server/last-modified-time', server.getServerListLastModifiedTime);
     app.get('/api/v1/server-detailed-status', getServerDetailedStatus);
+    app.post('/api/v2/server/list-update', server.updateServerList);
 
     app.get('/api/v2/user', user.getAll);
     app.get('/api/v2/user/extra-info/:userIdList', user.getMoreInfoByUserIdList);

--- a/project/dexter-monitor/routes/server.js
+++ b/project/dexter-monitor/routes/server.js
@@ -65,6 +65,7 @@ function loadServerList() {
 function initServerStatusValues() {
     const date = new Date().getTime();
     serverList.forEach((server) => {
+        server.projectName = _.trim(server.projectName);
         const lastDigitOfHostIP = server.hostIP.split('.')[3];
         server.name = `${server.projectName}(${lastDigitOfHostIP}:${server.portNumber})`;
         server.rerunLastTryTime = date;

--- a/project/dexter-monitor/routes/server.js
+++ b/project/dexter-monitor/routes/server.js
@@ -34,16 +34,38 @@ const _ = require('lodash');
 let serverList = [];
 let serverListLastModifiedTime = new Date();
 let checkingServerStatus;
+let doNotStartChecking;
 
-exports.init = function(doNotStartChecking){
+exports.init = function(_doNotStartChecking){
 
     mailing.init();
 
-    loadServerList()
+    doNotStartChecking = _doNotStartChecking;
+    updateServerListInternal();
+};
+
+function updateServerListInternal() {
+    if (checkingServerStatus) {
+        stopCheckingServerStatus();
+    }
+
+    return loadServerList()
         .then(initServerStatusValues)
         .then(() => {
             if (!doNotStartChecking)
                 startCheckingServerStatus();
+        });
+}
+
+exports.updateServerList = function(req, res) {
+    updateServerListInternal()
+        .then(() => {
+            log.info('ServerList updated');
+            res.send({status:'ok'});
+        })
+        .catch((err) => {
+            log.error(`Failed to update ServerList : ${err.message}`);
+            res.send({status:"fail", errorMessage: err.message});
         });
 };
 
@@ -156,6 +178,7 @@ function createEmailContentsWhenServerDown(server){
 
 function stopCheckingServerStatus(){
     clearInterval(checkingServerStatus);
+    checkingServerStatus = null;
 }
 
 exports.getConfig = function(req, res) {


### PR DESCRIPTION
When a dexter-server is added to DB, dexter-monitor should be re-started again to update server list before.
This commit adds an API to resolve this inconvenience.