### PR TITLE
[monitor] Display timed out server count

### DIFF
--- a/project/dexter-monitor/app.js
+++ b/project/dexter-monitor/app.js
@@ -173,8 +173,16 @@ function initModules(){
 
 function startServer(){
     if(!global.config.port || global.config.port < 1024 || global.config.port >= 65535){
-        console.log("you should set the port for monitor server")
+        log.error("you should set the port for monitor server")
         process.exit(-2);
+    }
+    if(!global.config.serverRequestTimeout || global.config.serverRequestTimeout < 1) {
+        log.error("serverRequestTimeout value should be greater than or equal to 1 (5 is set instead)");
+        global.config.serverRequestTimeout = 5;
+    }
+    if(!global.config.projectStatusRefreshInterval || global.config.projectStatusRefreshInterval < 5) {
+        log.error("projectStatusRefreshInterval value should be greater than or equal to 5 (60 is set instead)");
+        global.config.projectStatusRefreshInterval = 60;
     }
 
     http.createServer(app).listen(global.config.port, function(){

--- a/project/dexter-monitor/app.js
+++ b/project/dexter-monitor/app.js
@@ -148,6 +148,7 @@ function setWebApis(){
     app.get('/api/v1/server/last-modified-time', server.getServerListLastModifiedTime);
     app.get('/api/v1/server-detailed-status', getServerDetailedStatus);
     app.post('/api/v2/server/list-update', server.updateServerList);
+    app.get('/api/v1/server/config', server.getConfig);
 
     app.get('/api/v2/user', user.getAll);
     app.get('/api/v2/user/extra-info/:userIdList', user.getMoreInfoByUserIdList);

--- a/project/dexter-monitor/config.json
+++ b/project/dexter-monitor/config.json
@@ -4,6 +4,8 @@
     "description":"This program will monitor and control servers",
     "serverStatusCheckInterval":5,
     "serverDetailedStatusCheckInterval":5,
+    "serverRequestTimeout":5,
+    "projectStatusRefreshInterval":60,
     "snapshotDayOfWeek":2,
     "email":{
         "type":"api",

--- a/project/dexter-monitor/public/css/view.css
+++ b/project/dexter-monitor/public/css/view.css
@@ -61,6 +61,11 @@ body {
   font-weight: bold;
 }
 
+.server-status-active-timeout {
+  color: blue;
+  font-weight: bold;
+}
+
 .server-status-inactive {
   color: red;
   font-weight: bold;

--- a/project/dexter-monitor/public/ctrl/currentProjectCtrl.js
+++ b/project/dexter-monitor/public/ctrl/currentProjectCtrl.js
@@ -144,6 +144,6 @@ monitorApp.controller("CurrentProjectCtrl", function($scope, $http, $log, $inter
     });
 
     $scope.reloadPage = function() {
-        $window.location.reload();
+        $window.location.reload(true);
     }
 });

--- a/project/dexter-monitor/public/ctrl/currentProjectCtrl.js
+++ b/project/dexter-monitor/public/ctrl/currentProjectCtrl.js
@@ -49,7 +49,8 @@ monitorApp.controller("CurrentProjectCtrl", function($scope, $http, $log, $inter
             aggregationType: () => `Active: ${$scope.activeServerCount} / Inactive: ${$scope.allServerCount-$scope.activeServerCount}`,
             cellTemplate:'<div class="ui-grid-cell-contents"' +
                         ' ng-class="{\'server-status-active\':COL_FIELD == \'Active\',' +
-                        '            \'server-status-inactive\':COL_FIELD == \'Inactive\'}">{{COL_FIELD}}</div>'}
+                        '            \'server-status-inactive\':COL_FIELD == \'Inactive\',' +
+                        '            \'server-status-active-timeout\':COL_FIELD == \'Active (Timed out)\'}">{{COL_FIELD}}</div>'}
     ];
 
     initialize();

--- a/project/dexter-monitor/public/service/projectService.js
+++ b/project/dexter-monitor/public/service/projectService.js
@@ -50,7 +50,7 @@ monitorApp.service('ProjectService', function($http, $log, $q, ServerStatusServi
             .then((res) => {
                 if (!isHttpResultOK(res)) {
                     $log.error('Failed to get user count of ' + projectName);
-                    if (timedOutProjectNames && _.includes(res.data.errorMessage, 'ETIMEDOUT')) {
+                    if (timedOutProjectNames && _.includes(res.data.errorMessage, 'TIMEDOUT')) {
                         timedOutProjectNames.push(projectName);
                     }
                     deferred.resolve();
@@ -74,7 +74,7 @@ monitorApp.service('ProjectService', function($http, $log, $q, ServerStatusServi
             .then((res) => {
                 if (!isHttpResultOK(res)) {
                     $log.error('Failed to get defect status count of ' + projectName);
-                    if (timedOutProjectNames && _.includes(res.data.errorMessage, 'ETIMEDOUT')) {
+                    if (timedOutProjectNames && _.includes(res.data.errorMessage, 'TIMEDOUT')) {
                         timedOutProjectNames.push(projectName);
                     }
                     deferred.resolve();

--- a/project/dexter-monitor/public/service/serverStatusService.js
+++ b/project/dexter-monitor/public/service/serverStatusService.js
@@ -76,6 +76,20 @@ monitorApp.service('ServerStatusService', function($http, $log) {
             });
     };
 
+    service.getAllServerStatus = function() {
+        return $http.get("/api/v1/server")
+            .then((results) => {
+                const activeCount = _.filter(results.data, {'active': true}).length;
+                const inactiveCount = _.filter(results.data, {'active': false}).length;
+                return {'activeCount': activeCount, 'inactiveCount': inactiveCount};
+            })
+            .catch((err) => {
+                $log.error(err);
+                alert(`Failed to load server status.\nPlease contact the system administrator.\n${err}`);
+                return {};
+            });
+    };
+
     var localLastModifiedTimeOfServers = new Date();
     var currentLoadingCount = 0;
     var MAX_LOADING_COUNT = 10;

--- a/project/dexter-monitor/public/service/userService.js
+++ b/project/dexter-monitor/public/service/userService.js
@@ -51,14 +51,14 @@ monitorApp.service('UserService', function($http, $log, $q) {
             .then((res) => {
                 if (!isHttpResultOK(res)) {
                     $log.error('Failed to get user list');
-                    return [];
+                    return {rows: [], timedOutProjectNames: []};
                 }
 
-                return res.data.rows;
+                return res.data;
             })
             .catch((err) => {
                 $log.error(err);
-                return [];
+                return {rows: [], timedOutProjectNames: []};
             });
     };
 
@@ -67,14 +67,14 @@ monitorApp.service('UserService', function($http, $log, $q) {
             .then((res) => {
                 if (!isHttpResultOK(res)) {
                     $log.error('Failed to get user status list');
-                    return [];
+                    return {rows: [], timedOutProjectNames: []};
                 }
 
-                return res.data.rows;
+                return res.data;
             })
             .catch((err) => {
                 $log.error(err);
-                return [];
+                return {rows: [], timedOutProjectNames: []};
             });
     };
 });

--- a/project/dexter-monitor/public/view/currentProjectCtrl.html
+++ b/project/dexter-monitor/public/view/currentProjectCtrl.html
@@ -2,7 +2,8 @@
     <div>
         <div>
             <span style="font-size:18pt">Current status of all projects</span>
-            <span style="font-size:11pt"> ({{time}}) - Auto refresh every 10 seconds<b>{{dots}}</b></span>
+            <span style="font-size:11pt"> ({{time}}) - Auto refresh after <b>{{remainingTimeToRefresh}}</b> secs</span>
+            <button class="btn btn-primary btn-xs" role="button" ng-click="reloadPage()">Refresh Now!</button>
         </div>
         <div class="grid-current-project" id='currentProjectGrid' ui-grid="gridOptions"
              ui-grid-resize-columns ui-grid-move-columns ui-grid-selection ui-grid-exporter ui-grid-auto-resize>

--- a/project/dexter-monitor/public/view/currentUserView.html
+++ b/project/dexter-monitor/public/view/currentUserView.html
@@ -3,6 +3,7 @@
         <div>
             <span style="font-size:18pt">Current user list of all projects</span>
             <span style="font-size:11pt"> ({{time}})</span>
+            <span style="float:right;font-size:10pt;"><b>{{serverStatusString}}</b></span>
         </div>
         <div class="grid-current-user" id='currentUserGrid' ui-grid="gridOptions"
              ui-grid-resize-columns ui-grid-move-columns ui-grid-selection ui-grid-exporter ui-grid-auto-resize>

--- a/project/dexter-monitor/public/view/overviewView.html
+++ b/project/dexter-monitor/public/view/overviewView.html
@@ -12,6 +12,7 @@
         <div>
             <span style="font-size:18pt">Current installation status</span>
             <span style="font-size:11pt"> ({{time}})</span>
+            <span style="float:right;font-size:10pt;"><b>{{serverStatusStringForInstallationStatusGrid}}</b></span>
         </div>
         <div class="grid-overview-installation-status" id='overviewInstallationStatusGrid' ui-grid="installationStatusGridOptions"
              ui-grid-resize-columns ui-grid-move-columns ui-grid-selection ui-grid-exporter ui-grid-auto-resize>
@@ -20,6 +21,7 @@
         <div>
             <span style="font-size:18pt">Current defect status</span>
             <span style="font-size:11pt"> ({{time}})</span>
+            <span style="float:right;font-size:10pt"><b>{{serverStatusStringForDefectStatusGrid}}</b></span>
         </div>
         <div class="grid-overview-defect-status" id='overviewDefectStatusGrid' ui-grid="defectStatusGridOptions"
              ui-grid-resize-columns ui-grid-move-columns ui-grid-selection ui-grid-exporter ui-grid-auto-resize>

--- a/project/dexter-monitor/routes/defect.js
+++ b/project/dexter-monitor/routes/defect.js
@@ -117,7 +117,7 @@ exports.getMaxWeek = function(req, res) {
 exports.getDefectCountByProjectName = function(req, res) {
     const projectServer = _.find(server.getServerListInternal(), {'projectName': req.params.projectName});
     const defectCountUrl = `http://${projectServer.hostIP}:${projectServer.portNumber}/api/v2/defect-count`;
-    rp(defectCountUrl)
+    rp({uri: defectCountUrl, timeout: 2000})
         .then((data) => {
             const parsedData = JSON.parse('' + data);
             res.send({status:'ok', values: parsedData.values});
@@ -139,7 +139,7 @@ exports.saveSnapshot = function() {
         let userCount = 0;
 
         promises.push(new Promise((resolve, reject) => {
-            rp(defectCountUrl)
+            rp({uri: defectCountUrl, timeout: 2000})
                 .then((data) => {
                     defectValues = JSON.parse('' + data).values;
                     resolve();
@@ -150,7 +150,7 @@ exports.saveSnapshot = function() {
                 });
         }));
         promises.push(new Promise((resolve, reject) => {
-            rp(userCountUrl)
+            rp({uri: userCountUrl, timeout: 2000})
                 .then((data) => {
                     userCount = JSON.parse('' + data).value;
                     resolve();

--- a/project/dexter-monitor/routes/defect.js
+++ b/project/dexter-monitor/routes/defect.js
@@ -117,7 +117,7 @@ exports.getMaxWeek = function(req, res) {
 exports.getDefectCountByProjectName = function(req, res) {
     const projectServer = _.find(server.getServerListInternal(), {'projectName': req.params.projectName});
     const defectCountUrl = `http://${projectServer.hostIP}:${projectServer.portNumber}/api/v2/defect-count`;
-    rp({uri: defectCountUrl, timeout: 2000})
+    rp({uri: defectCountUrl, timeout: global.config.serverRequestTimeout * 1000})
         .then((data) => {
             const parsedData = JSON.parse('' + data);
             res.send({status:'ok', values: parsedData.values});
@@ -139,7 +139,7 @@ exports.saveSnapshot = function() {
         let userCount = 0;
 
         promises.push(new Promise((resolve, reject) => {
-            rp({uri: defectCountUrl, timeout: 2000})
+            rp({uri: defectCountUrl, timeout: global.config.serverRequestTimeout * 1000})
                 .then((data) => {
                     defectValues = JSON.parse('' + data).values;
                     resolve();
@@ -150,7 +150,7 @@ exports.saveSnapshot = function() {
                 });
         }));
         promises.push(new Promise((resolve, reject) => {
-            rp({uri: userCountUrl, timeout: 2000})
+            rp({uri: userCountUrl, timeout: global.config.serverRequestTimeout * 1000})
                 .then((data) => {
                     userCount = JSON.parse('' + data).value;
                     resolve();

--- a/project/dexter-monitor/routes/project.js
+++ b/project/dexter-monitor/routes/project.js
@@ -120,7 +120,7 @@ function loadDefectStatusSummary(resolve, summary) {
 
     Promise.map(activeServerList, (server) => {
         const defectCountUrl = `http://${server.hostIP}:${server.portNumber}/api/v2/defect-count`;
-        return rp(defectCountUrl)
+        return rp({uri: defectCountUrl, timeout: 2000})
             .then((data) => {
                 server.defectValues = JSON.parse('' + data).values;
             })

--- a/project/dexter-monitor/routes/project.js
+++ b/project/dexter-monitor/routes/project.js
@@ -120,7 +120,7 @@ function loadDefectStatusSummary(resolve, summary) {
 
     Promise.map(activeServerList, (server) => {
         const defectCountUrl = `http://${server.hostIP}:${server.portNumber}/api/v2/defect-count`;
-        return rp({uri: defectCountUrl, timeout: 2000})
+        return rp({uri: defectCountUrl, timeout: global.config.serverRequestTimeout * 1000})
             .then((data) => {
                 server.defectValues = JSON.parse('' + data).values;
             })

--- a/project/dexter-monitor/routes/server.js
+++ b/project/dexter-monitor/routes/server.js
@@ -182,7 +182,7 @@ function stopCheckingServerStatus(){
 }
 
 exports.getConfig = function(req, res) {
-    res.send(config);
+    res.send(global.config);
 };
 
 exports.getServerListLastModifiedTime = function(req, res) {

--- a/project/dexter-monitor/routes/user.js
+++ b/project/dexter-monitor/routes/user.js
@@ -40,7 +40,7 @@ const requestify = require('requestify');
 
 
 function getUserList(userListUrl){
-    return requestify.get(userListUrl, {timeout: 2000})
+    return requestify.get(userListUrl, {timeout: global.config.serverRequestTimeout * 1000})
         .then(function(result){
             const jsonObj = JSON.parse(result.body);
             return jsonObj.rows;
@@ -98,7 +98,7 @@ function processReturnedData(data) {
 }
 
 function loadUserInfo(userId, userInfoUrl, userInfoList) {
-    return rp({uri: userInfoUrl + userId, timeout: 2000})
+    return rp({uri: userInfoUrl + userId, timeout: global.config.serverRequestTimeout * 1000})
         .then((data) => {
             data = processReturnedData(data);
             if (!data || !validateUserInfoJson(data, userId)) {
@@ -153,7 +153,7 @@ function validateUserInfoJson(data, userid) {
 exports.getUserCountByProjectName = function(req, res) {
     const projectServer = _.find(server.getServerListInternal(), {'projectName': req.params.projectName});
     const userCountUrl = `http://${projectServer.hostIP}:${projectServer.portNumber}/api/v2/user-count`;
-    rp({uri: userCountUrl, timeout: 2000})
+    rp({uri: userCountUrl, timeout: global.config.serverRequestTimeout * 1000})
         .then((data) => {
             const parsedData = JSON.parse('' + data);
             res.send({status:'ok', value: parsedData.value});
@@ -184,7 +184,7 @@ function loadUserList(timedOutProjectNames) {
     activeServerList.forEach( (server) =>
         promises.push(new Promise((resolve) => {
             const userListUrl = `http://${server.hostIP}:${server.portNumber}/api/v2/user-list`;
-            rp({uri: userListUrl, timeout: 2000})
+            rp({uri: userListUrl, timeout: global.config.serverRequestTimeout * 1000})
                 .then((data) => {
                     const rows = JSON.parse('' + data).rows;
                     if (rows) {


### PR DESCRIPTION
 * This commit is a temporary solution to resolve #94

 All current data are not displayed when there is at least one busy dexter-server.
 To temporarily resolve this problem,
  - Timeout option is added to all of the request calls to dexter-server.
  - If the timeout is exceeded, timed out project count is displayed.