### PR TITLE
Increased maximum data points count on Dexter Monitor Summary chart

### DIFF
--- a/project/dexter-monitor/public/util/chart.js
+++ b/project/dexter-monitor/public/util/chart.js
@@ -25,7 +25,7 @@
  */
 "use strict";
 
-const OVERVIEW_SUMMARY_CHART_MAX = 5;
+const OVERVIEW_SUMMARY_CHART_MAX = 52;
 
 function randomColorFactor() {
     return Math.round(Math.random() * 255);


### PR DESCRIPTION
There is no need to show only 5 latest weeks on the chart. I increased it to 52 - our monitors are wide enough for this.