### PR TITLE
[monitor] Automatic creation of dexter server instances

### DIFF
--- a/project/dexter-monitor/app.js
+++ b/project/dexter-monitor/app.js
@@ -164,6 +164,7 @@ function setWebApis(){
 
     app.get('/api/v2/project-list', project.getProjectList);
     app.get('/api/v2/snapshot-summary', project.getSnapshotSummary);
+	app.post('/api/v2/create-project',project.createProject);
 }
 
 function initModules(){

--- a/project/dexter-monitor/app.js
+++ b/project/dexter-monitor/app.js
@@ -164,7 +164,7 @@ function setWebApis(){
 
     app.get('/api/v2/project-list', project.getProjectList);
     app.get('/api/v2/snapshot-summary', project.getSnapshotSummary);
-	app.post('/api/v2/create-project',project.createProject);
+	app.post('/api/v2/project',project.createProject);
 }
 
 function initModules(){

--- a/project/dexter-monitor/bower.json
+++ b/project/dexter-monitor/bower.json
@@ -31,7 +31,8 @@
     "lodash": "^4.13.1",
     "angular-bootstrap": "^1.3.3",
     "DateJS": "datejs#^1.0.0-rc3",
-    "chart.js": "npm:chart.js#^2.2.1"
+    "chart.js": "npm:chart.js#^2.2.1",
+    "angular-material": "^1.1.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.9"

--- a/project/dexter-monitor/config.json
+++ b/project/dexter-monitor/config.json
@@ -20,5 +20,6 @@
         "password":"Database User Password",
         "name":"Database Name"
     },
-    "userInfoUrl":"User info URL"
+    "userInfoUrl":"User info URL",
+	"dexterServerPath":"../dexter-server/"
 }

--- a/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
+++ b/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
@@ -25,16 +25,18 @@
  */
 "use strict";
 
-monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log, $location, ProjectService) {
+monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log, $location, $sce, ProjectService) {
 
     initialize();
 
     function initialize() {
     }
-
-
+		$scope.$watch('newProject', function(newProject){
+			$scope.status =  $sce.trustAsHtml('Server will be created on <a href="' + newProject.hostName + ":" + newProject.portNumber + "/#/\">" + newProject.hostName + ":" + newProject.portNumber + "</a>");
+		},true);
+	
 		$scope.languages = ["CPP", "JAVA"];
-		$scope.newProject = {hostName: $location.host()};
+		$scope.newProject = {hostName: $location.host(), portNumber:""};
 					
 		$scope.showCreateProjectDialog = function(ev) {
 						
@@ -55,7 +57,16 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 					$scope.validationError = errorMessage;
 					$log.error($scope.validationError);
 				} else {
-					$mdDialog.hide();
+						$scope.status =  $sce.trustAsHtml("Creating new server ");
+					ProjectService.createProject(newProject).then (function(result) {
+						$log.info(result);
+						if (result.data.status==200) {
+							$scope.status =  $sce.trustAsHtml("Server created successfully!");							
+						} else {
+							$scope.status =  $sce.trustAsHtml("Server creation failed!");
+							$scope.validationError = result.data.errorMessage;
+						}
+					});					
 				}
 			});						
 		};
@@ -65,7 +76,7 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 		}
 		
 		function validateProjectData(newProject) {
-			
+
 			let validationResult = validateCompletness(newProject);
 			
 			if (validationResult) {

--- a/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
+++ b/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
@@ -25,7 +25,7 @@
  */
 "use strict";
 
-monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log, ProjectService) {
+monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log, $location, ProjectService) {
 
     initialize();
 
@@ -34,9 +34,10 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 
 
 		$scope.languages = ["CPP", "JAVA"];
-		
+		$scope.newProject = {hostName: $location.host()};
+					
 		$scope.showCreateProjectDialog = function(ev) {
-			
+						
 			$mdDialog.show({
 			controller: "ProjectManagementCtrl",
 			  templateUrl: '/view/createServerDialog.html',
@@ -108,6 +109,7 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 					return "Port Number is already in use";
 				}
 			});
-		}		
+		}
+
 		
 });

--- a/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
+++ b/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
@@ -50,24 +50,24 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 		};
 		
 		$scope.createServer = function(newProject) {
-			
+			$scope.clearValidationError();
 			validateProjectData(newProject).then(
 			(errorMessage) => {
 				if (errorMessage) {
 					$scope.validationError = errorMessage;
 					$log.error($scope.validationError);
-				} else {
-						$scope.validationError = "";
-						$scope.status =  $sce.trustAsHtml("Creating new server...");
-					ProjectService.createProject(newProject).then (function(result) {
-						if (result.data.status=='ok') {
-							$scope.status =  $sce.trustAsHtml('Server created at <a href="' + newProject.hostIp + ":" + newProject.portNumber + "/#/\">" + newProject.hostIp + ":" + newProject.portNumber + "</a> !");						
-						} else {
-							$scope.status =  $sce.trustAsHtml("Server creation failed!");
-							$scope.validationError = result.data.errorMessage;
-						}
-					});					
-				}
+					return;
+				}  
+				$scope.status =  $sce.trustAsHtml("Creating new server...");
+
+				ProjectService.createProject(newProject).then (function(result) {
+					if (result.data.status=='ok') {
+						$scope.status =  $sce.trustAsHtml('Server created at <a href="' + newProject.hostIp + ":" + newProject.portNumber + "/#/\">" + newProject.hostIp + ":" + newProject.portNumber + "</a> !");					
+					} else {
+						$scope.status =  $sce.trustAsHtml("Server creation failed!");
+						$scope.validationError = result.data.errorMessage;
+					}
+				});			
 			});						
 		};
 		
@@ -108,7 +108,7 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 		
 		function validateProjectName(newProject) {
 			let projectName = newProject.projectName;
-			if (!(projectName.match(/^[a-z0-9]+$/i))) {
+			if (!(projectName.match(/^[a-z0-9_]+$/i))) {
 				return 'Project name can contain only numbers and letters';
 			}
 		}

--- a/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
+++ b/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
@@ -32,7 +32,7 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
     function initialize() {
     }
 		$scope.$watch('newProject', function(newProject){
-			$scope.status =  $sce.trustAsHtml('Server will be created on <a href="' + newProject.hostName + ":" + newProject.portNumber + "/#/\">" + newProject.hostName + ":" + newProject.portNumber + "</a>");
+			$scope.status =  $sce.trustAsHtml('Server will be created at <a href="' + newProject.hostName + ":" + newProject.portNumber + "/#/\">" + newProject.hostName + ":" + newProject.portNumber + "</a>");
 		},true);
 	
 		$scope.languages = ["CPP", "JAVA"];
@@ -57,11 +57,11 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 					$scope.validationError = errorMessage;
 					$log.error($scope.validationError);
 				} else {
-						$scope.status =  $sce.trustAsHtml("Creating new server ");
+						$scope.validationError = "";
+						$scope.status =  $sce.trustAsHtml("Creating new server...");
 					ProjectService.createProject(newProject).then (function(result) {
-						$log.info(result);
-						if (result.data.status==200) {
-							$scope.status =  $sce.trustAsHtml("Server created successfully!");							
+						if (result.data.status=='ok') {
+							$scope.status =  $sce.trustAsHtml('Server created at <a href="' + newProject.hostName + ":" + newProject.portNumber + "/#/\">" + newProject.hostName + ":" + newProject.portNumber + "</a> !");						
 						} else {
 							$scope.status =  $sce.trustAsHtml("Server creation failed!");
 							$scope.validationError = result.data.errorMessage;

--- a/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
+++ b/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
@@ -32,11 +32,11 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
     function initialize() {
     }
 		$scope.$watch('newProject', function(newProject){
-			$scope.status =  $sce.trustAsHtml('Server will be created at <a href="' + newProject.hostName + ":" + newProject.portNumber + "/#/\">" + newProject.hostName + ":" + newProject.portNumber + "</a>");
+			$scope.status =  $sce.trustAsHtml('Server will be created at <a href="' + newProject.hostIp + ":" + newProject.portNumber + "/#/\">" + newProject.hostIp + ":" + newProject.portNumber + "</a>");
 		},true);
 	
 		$scope.languages = ["CPP", "JAVA"];
-		$scope.newProject = {hostName: $location.host(), portNumber:""};
+		$scope.newProject = {hostIp: $location.host(), portNumber:""};
 					
 		$scope.showCreateProjectDialog = function(ev) {
 						
@@ -61,7 +61,7 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 						$scope.status =  $sce.trustAsHtml("Creating new server...");
 					ProjectService.createProject(newProject).then (function(result) {
 						if (result.data.status=='ok') {
-							$scope.status =  $sce.trustAsHtml('Server created at <a href="' + newProject.hostName + ":" + newProject.portNumber + "/#/\">" + newProject.hostName + ":" + newProject.portNumber + "</a> !");						
+							$scope.status =  $sce.trustAsHtml('Server created at <a href="' + newProject.hostIp + ":" + newProject.portNumber + "/#/\">" + newProject.hostIp + ":" + newProject.portNumber + "</a> !");						
 						} else {
 							$scope.status =  $sce.trustAsHtml("Server creation failed!");
 							$scope.validationError = result.data.errorMessage;

--- a/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
+++ b/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
@@ -25,11 +25,24 @@
  */
 "use strict";
 
-monitorApp.controller("ProjectManagementCtrl", function($scope) {
+monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog) {
 
     initialize();
 
     function initialize() {
     }
 
+		$scope.createProject = function($event) {
+		
+			$mdDialog.show(
+			  $mdDialog.alert()
+				.parent(angular.element(document.querySelector('#popupContainer')))
+				.clickOutsideToClose(true)
+				.title('Create new Dexter Server')
+				.textContent('You can specify some description text in here.')
+				.ok('Create')
+				.targetEvent($event)
+			);
+		};
+		
 });

--- a/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
+++ b/project/dexter-monitor/public/ctrl/projectManagementCtrl.js
@@ -77,7 +77,7 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 		
 		function validateProjectData(newProject) {
 
-			let validationResult = validateCompletness(newProject);
+			let validationResult = validateCompletness(newProject) || validateProjectName(newProject);
 			
 			if (validationResult) {
 				return Promise.resolve(validationResult);
@@ -104,6 +104,13 @@ monitorApp.controller("ProjectManagementCtrl", function($scope, $mdDialog, $log,
 			} else if (!newProject.adminPassword) {
 				return "Administrator password must not empty";
 			} 
+		}
+		
+		function validateProjectName(newProject) {
+			let projectName = newProject.projectName;
+			if (!(projectName.match(/^[a-z0-9]+$/i))) {
+				return 'Project name can contain only numbers and letters';
+			}
 		}
 		
 		function validateProjectNameUsage(newProject) {

--- a/project/dexter-monitor/public/dexterMonitorApp.js
+++ b/project/dexter-monitor/public/dexterMonitorApp.js
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var monitorApp = angular.module("dexterMonitorApp", ['ngRoute', 'ngAnimate', 'ngTouch', 'ngMaterial',
+var monitorApp = angular.module("dexterMonitorApp", ['ngRoute', 'ngAnimate', 'ngMaterial',
         'ui.grid', 'ui.grid.resizeColumns', 'ui.grid.moveColumns', 'ui.grid.exporter', 'ui.grid.autoResize',
         'ui.bootstrap'])
     .factory('_', ['$window', function($window){

--- a/project/dexter-monitor/public/dexterMonitorApp.js
+++ b/project/dexter-monitor/public/dexterMonitorApp.js
@@ -23,7 +23,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var monitorApp = angular.module("dexterMonitorApp", ['ngRoute', 'ngAnimate', 'ngTouch',
+var monitorApp = angular.module("dexterMonitorApp", ['ngRoute', 'ngAnimate', 'ngTouch', 'ngMaterial',
         'ui.grid', 'ui.grid.resizeColumns', 'ui.grid.moveColumns', 'ui.grid.exporter', 'ui.grid.autoResize',
         'ui.bootstrap'])
     .factory('_', ['$window', function($window){

--- a/project/dexter-monitor/public/index.html
+++ b/project/dexter-monitor/public/index.html
@@ -6,6 +6,7 @@
     <title>Dexter Monitor</title>
 
     <link rel="stylesheet" href="js/angular-ui-grid/ui-grid.min.css" />
+	<link rel="stylesheet" href="js/angular-material/angular-material.css">
     <link rel="stylesheet" href="js/bootstrap/dist/css/bootstrap.min.css" />
     <!-- iCheck for checkboxes and radio inputs -->
     <link rel="stylesheet" href="../../plugins/iCheck/all.css">
@@ -26,8 +27,11 @@
     <script src="js/angular-route/angular-route.min.js"></script>
     <script src="js/angular-touch/angular-touch.min.js"></script>
     <script src="js/angular-animate/angular-animate.min.js"></script>
+	<script src="js/angular-aria/angular-aria.min.js"></script>
+	<script src="js/angular-messages/angular-messages.min.js"></script>
     <script src="js/angular-ui-grid/ui-grid.min.js"></script>
     <script src="js/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
+	<script src="js/angular-material/angular-material.js"></script>
     <script src="js/pdfmake/build/pdfmake.min.js"></script>
     <script src="js/pdfmake/build/vfs_fonts.js"></script>
     <script src="js/jquery/dist/jquery.min.js"></script>

--- a/project/dexter-monitor/public/service/projectService.js
+++ b/project/dexter-monitor/public/service/projectService.js
@@ -206,4 +206,22 @@ monitorApp.service('ProjectService', function($http, $log, $q, ServerStatusServi
                 return [];
             });
     };
+	
+	this.isProjectNameUsed = function(projectName) {
+        return ServerStatusService.getActiveServerList()
+            .then((rows) => {
+				let projectNames = _.map(rows, 'projectName');
+				let projectNamesUsed = _.filter(projectNames, (usedProjectName) => usedProjectName==projectName);
+				return projectNamesUsed.length>0;
+            });
+	}
+	
+	this.isPortNumberUsed = function(portNumber) {
+        return ServerStatusService.getActiveServerList()
+            .then((rows) => {
+				let portNumbers = _.map(rows, 'portNumber');
+				let portNumbersUsed = _.filter(portNumbers, (usedPortNumber) => usedPortNumber==portNumber);
+				return portNumbersUsed.length>0;
+            });
+	}
 });

--- a/project/dexter-monitor/public/service/projectService.js
+++ b/project/dexter-monitor/public/service/projectService.js
@@ -226,6 +226,6 @@ monitorApp.service('ProjectService', function($http, $log, $q, ServerStatusServi
 	}
 	
 	this.createProject = function(newProject) {
-		return $http.post('/api/v2/create-project', {project:newProject});
+		return $http.post('/api/v2/project', {project:newProject});
 	}
 });

--- a/project/dexter-monitor/public/service/projectService.js
+++ b/project/dexter-monitor/public/service/projectService.js
@@ -224,4 +224,8 @@ monitorApp.service('ProjectService', function($http, $log, $q, ServerStatusServi
 				return portNumbersUsed.length>0;
             });
 	}
+	
+	this.createProject = function(newProject) {
+		return $http.post('/api/v2/create-project', {project:newProject});
+	}
 });

--- a/project/dexter-monitor/public/sidebar.html
+++ b/project/dexter-monitor/public/sidebar.html
@@ -21,7 +21,7 @@
 	    <ul class="nav nav-sidebar" ng-controller="ProjectManagementCtrl" >
             <li><div><h3><b><i class="fa fa-cog"></i> Server</b></h3></div></li>
             <li>
-                <a href='' ng-click="createProject($event)" uib-tooltip="Create new Dexter Server instance" tooltip-placement="right" tooltip-append-to-body="true">Create Server</a></li>
+                <a href='' ng-click="showCreateProjectDialog($event)" uib-tooltip="Create new Dexter Server instance" tooltip-placement="right" tooltip-append-to-body="true">Create Server</a></li>
         </ul>
     </div>
 </div>

--- a/project/dexter-monitor/public/sidebar.html
+++ b/project/dexter-monitor/public/sidebar.html
@@ -17,5 +17,12 @@
             <li ng-class="{'active':isActiveView('/weekly-project/')}">
                 <a href="#/weekly-project/" uib-tooltip="Weekly defect status of all projects" tooltip-placement="right" tooltip-append-to-body="true">Project Status</a></li>
         </ul>
+		<br>
+	    <ul class="nav nav-sidebar" ng-controller="ProjectManagementCtrl" >
+            <li><div><h3><b><i class="fa fa-cog"></i> Server</b></h3></div></li>
+            <li>
+                <a href='' ng-click="createProject($event)" uib-tooltip="Create new Dexter Server instance" tooltip-placement="right" tooltip-append-to-body="true">Create Server</a></li>
+        </ul>
     </div>
 </div>
+<div class="md-padding dialogdemoBasicUsage" id="popupContainer" ng-cloak="" ></div>

--- a/project/dexter-monitor/public/util/chart.js
+++ b/project/dexter-monitor/public/util/chart.js
@@ -25,7 +25,7 @@
  */
 "use strict";
 
-const OVERVIEW_SUMMARY_CHART_MAX = 5;
+const OVERVIEW_SUMMARY_CHART_MAX = 52;
 
 function randomColorFactor() {
     return Math.round(Math.random() * 255);

--- a/project/dexter-monitor/public/view/createServerDialog.html
+++ b/project/dexter-monitor/public/view/createServerDialog.html
@@ -28,7 +28,7 @@
 				<input ng-model="newProject.adminPassword" ng-change="clearValidationError()" placeholder="e.g. MyPa$$word">
 			</md-input-container>
 		</div>
-		<div> Server will be created on <a ng-model="newProject" href="http://{{newProject.hostName}}:{{newProject.portNumber}}/#" >{{newProject.hostName}}:{{newProject.portNumber}}</a></div> 
+		<div ng-bind-html="status" > </div> 
 		<div style="color: red" ng-model="validationError" > {{validationError}} </div>
 	</md-dialog-content>
 		

--- a/project/dexter-monitor/public/view/createServerDialog.html
+++ b/project/dexter-monitor/public/view/createServerDialog.html
@@ -28,6 +28,7 @@
 				<input ng-model="newProject.adminPassword" ng-change="clearValidationError()" placeholder="e.g. MyPa$$word">
 			</md-input-container>
 		</div>
+		<div> Server will be created on <a ng-model="newProject" href="http://{{newProject.hostName}}:{{newProject.portNumber}}/#" >{{newProject.hostName}}:{{newProject.portNumber}}</a></div> 
 		<div style="color: red" ng-model="validationError" > {{validationError}} </div>
 	</md-dialog-content>
 		

--- a/project/dexter-monitor/public/view/createServerDialog.html
+++ b/project/dexter-monitor/public/view/createServerDialog.html
@@ -1,0 +1,40 @@
+<md-dialog layout-padding="" >
+	<md-dialog-content>
+		<div>
+			<h2>Create new Dexter Server</h2>
+			</br>
+			<md-input-container class="md-block" flex-gt-xs="">
+				<label>Project Name</label>
+				<input ng-model="newProject.projectName" ng-change="clearValidationError()" placeholder="e.g. 15_TEST_PROJECT">
+			</md-input-container>
+			<md-input-container class="md-block" flex-gt-sm="">
+				<label>Project Language</label>
+				<md-select ng-model="newProject.language" ng-change="clearValidationError()"  >
+					<md-option ng-repeat="language in languages" value="{{language}}" ng-selected="$first">
+						{{language}}
+					</md-option>
+				</md-select>
+			</md-input-container>
+			<md-input-container  class="md-block" flex-gt-sm="">
+				<label>Port Number</label>
+				<input type="number" ng-model="newProject.portNumber" ng-change="clearValidationError()" placeholder="e.g. 1234">
+			</md-input-container>
+			<md-input-container class="md-block" flex-gt-xs="">
+				<label>Administrator Name</label>
+				<input ng-model="newProject.adminName" ng-change="clearValidationError()" placeholder="e.g. j.doe">
+			</md-input-container>
+			<md-input-container class="md-block" flex-gt-xs="" >
+				<label>Administrator Password</label>
+				<input ng-model="newProject.adminPassword" ng-change="clearValidationError()" placeholder="e.g. MyPa$$word">
+			</md-input-container>
+		</div>
+		<div style="color: red" ng-model="validationError" > {{validationError}} </div>
+	</md-dialog-content>
+		
+    <md-dialog-actions layout="row">
+      <span flex></span>
+      <md-button ng-click="createServer(newProject)" >
+        Create Server
+      </md-button>
+    </md-dialog-actions>
+</md-dialog>

--- a/project/dexter-monitor/routes/project.js
+++ b/project/dexter-monitor/routes/project.js
@@ -71,6 +71,24 @@ exports.saveSnapshotSummary = function() {
         })
 };
 
+exports.createProject = function(req, res) {
+
+	createProjectInternal()
+    .then(() => {
+        log.info('Dexter Server instance created');
+		res.send({status:"ok", errorMessage: err.message});
+    })
+    .catch((err) => {
+        log.error(`Failed to create Dexter Server instance : ${err.message}`);
+        res.send({status:"fail", errorMessage: err.message});
+    });
+
+};
+
+function createProjectInternal(resolve, summary) {
+	return new Promise((resolve, summary) => {resolve();});
+}
+
 function insertSnapshotSummaryToDatabase(summary) {
     const year = moment().get('year');
     const weekOfYear = moment().isoWeek();

--- a/project/dexter-monitor/routes/project.js
+++ b/project/dexter-monitor/routes/project.js
@@ -85,7 +85,7 @@ exports.createProject = function(req, res) {
 		
 		//wait for the dexter server to start
 		setTimeout( () => {
-			log.info('Dexter Server instance created at:' + project.hostName + ":" + project.portNumber );
+			log.info('Dexter Server instance created at:' + project.hostIp + ":" + project.portNumber );
 			res.send({status:"ok"});
 		}, 5000);
     })
@@ -104,7 +104,7 @@ function createDexterServerDatabase(project) {
 
 function insertDexterMonitorEntry(project) {
 	const sql = `INSERT INTO ProjectInfo (projectName, pid, requester, administrator, portNumber, createdDateTime, language, hostIP, projectYear, emailingWhenServerDead, groupName, dbName) VALUES (?,?,?,?,?, now(), ?, ?, YEAR(now()), 'Y', '',?)`;
-	const args  = [project.projectName, project.projectName, project.adminName, project.adminName, project.portNumber, project.language, project.hostName, project.projectName];
+	const args  = [project.projectName, project.projectName, project.adminName, project.adminName, project.portNumber, project.language, project.hostIp, project.projectName];
 	return database.exec(sql, args).then(() => project);
 }
 

--- a/project/dexter-monitor/routes/project.js
+++ b/project/dexter-monitor/routes/project.js
@@ -103,8 +103,9 @@ function createDexterServerDatabase(project) {
 }
 
 function insertDexterMonitorEntry(project) {
-	var sql = `INSERT INTO ProjectInfo (projectName, pid, requester, administrator, portNumber, createdDateTime, language, hostIP, projectYear, emailingWhenServerDead, groupName, dbName) VALUES ('${project.projectName}', '${project.projectName}','${project.adminName}', '${project.adminName}', '${project.portNumber}', now(), '${project.language}', '${project.hostName}', YEAR(now()), 'Y', '','${project.projectName}')`;
-	return database.exec(sql).then(() => project);
+	var sql = `INSERT INTO ProjectInfo (projectName, pid, requester, administrator, portNumber, createdDateTime, language, hostIP, projectYear, emailingWhenServerDead, groupName, dbName) VALUES (?,?,?,?,?, now(), ?, ?, YEAR(now()), 'Y', '',?)`;
+	var args  = [project.projectName, project.projectName, project.adminName, project.adminName, project.portNumber, project.language, project.hostName, project.projectName];
+	return database.exec(sql, args).then(() => project);
 }
 
 function startDexterServer(project) {

--- a/project/dexter-monitor/routes/project.js
+++ b/project/dexter-monitor/routes/project.js
@@ -96,44 +96,44 @@ exports.createProject = function(req, res) {
 }
 
 function createDexterServerDatabase(project) {
-	var sql = `CREATE DATABASE ${project.projectName}; USE ${project.projectName};`;
-		sql += fs.readFileSync(`${global.config.dexterServerPath}/config/ddl.sql`).toString();	
-		sql += `USE ${global.config.database.name};`;
+	const sql = `CREATE DATABASE ${project.projectName}; USE ${project.projectName};`
+			   + fs.readFileSync(`${global.config.dexterServerPath}/config/ddl.sql`).toString();	
+			   + `USE ${global.config.database.name};`;
 	return database.exec(sql).then(() => project);
 }
 
 function insertDexterMonitorEntry(project) {
-	var sql = `INSERT INTO ProjectInfo (projectName, pid, requester, administrator, portNumber, createdDateTime, language, hostIP, projectYear, emailingWhenServerDead, groupName, dbName) VALUES (?,?,?,?,?, now(), ?, ?, YEAR(now()), 'Y', '',?)`;
-	var args  = [project.projectName, project.projectName, project.adminName, project.adminName, project.portNumber, project.language, project.hostName, project.projectName];
+	const sql = `INSERT INTO ProjectInfo (projectName, pid, requester, administrator, portNumber, createdDateTime, language, hostIP, projectYear, emailingWhenServerDead, groupName, dbName) VALUES (?,?,?,?,?, now(), ?, ?, YEAR(now()), 'Y', '',?)`;
+	const args  = [project.projectName, project.projectName, project.adminName, project.adminName, project.portNumber, project.language, project.hostName, project.projectName];
 	return database.exec(sql, args).then(() => project);
 }
 
 function startDexterServer(project) {
-	var npmInstallCmd = `npm install`;
-	var nodeCmd = `node server.js -database.name=${project.projectName} -p=${project.portNumber} -database.host=${global.config.database.host} -database.user=${global.config.database.user} -database.password=${global.config.database.password}`;
+	const npmInstallCmd = `npm install`;
+	const nodeCmd = `node server.js -database.name=${project.projectName} -p=${project.portNumber} -database.host=${global.config.database.host} -database.user=${global.config.database.user} -database.password=${global.config.database.password}`;
 	var dexterServerPath = path.resolve(global.config.dexterServerPath);
 	log.info("Starting new Dexter Server instance");
 	var child;
         if (os.type()=="Linux") {
-		var supervisordEntry = `\n[program:dexter-${project.projectName}] \n` +
+		const supervisordEntry = `\n[program:dexter-${project.projectName}] \n` +
 					`command=` + nodeCmd + `\n` +
 					`directory=` + dexterServerPath;
-		var supervisordConfPath = '/etc/supervisord.conf';
+		const supervisordConfPath = '/etc/supervisord.conf';
                 try {
 		   // if supervisord is installed, dexter server will be managed by it
 		   fs.accessSync(supervisordConfPath);
                    fs.appendFileSync(supervisordConfPath,supervisordEntry);
-		   var cmd = "supervisorctl update";
+		   const cmd = "supervisorctl update";
 		   child = exec(cmd); 
 		   log.info("Added Supervisor entry");
                 } catch(err) {
 		   // if no supervisord is installed, the normal node process is run
-                   var cmd = npmInstallCmd + ' && ' + nodeCmd;	
+                   const cmd = npmInstallCmd + ' && ' + nodeCmd;	
 	           child = exec(cmd, {cwd: dexterServerPath});
                 }
 	} else {
-		cmd = 'start cmd /k' + '\"' + npmInstallCmd + ' && ' + nodeCmd + '\"';
-	        child = exec(cmd, {cwd: dexterServerPath, detached:true});
+		const cmd = 'start cmd /k' + '\"' + npmInstallCmd + ' && ' + nodeCmd + '\"';
+	    child = exec(cmd, {cwd: dexterServerPath, detached:true});
 	}
 	child.on('error', function( err ){ throw err });
 }

--- a/project/dexter-monitor/routes/project.js
+++ b/project/dexter-monitor/routes/project.js
@@ -96,9 +96,9 @@ exports.createProject = function(req, res) {
 }
 
 function createDexterServerDatabase(project) {
-	const sql = `CREATE DATABASE ${project.projectName}; USE ${project.projectName};`
-			   + fs.readFileSync(`${global.config.dexterServerPath}/config/ddl.sql`).toString();	
-			   + `USE ${global.config.database.name};`;
+	const sql = `CREATE DATABASE ${project.projectName}; USE ${project.projectName};`+
+			    fs.readFileSync(`${global.config.dexterServerPath}/config/ddl.sql`).toString()+
+			    `USE ${global.config.database.name};`;
 	return database.exec(sql).then(() => project);
 }
 

--- a/project/dexter-monitor/util/database.js
+++ b/project/dexter-monitor/util/database.js
@@ -71,7 +71,8 @@ function initDbPool(){
         password: _runOptions.databasePassword,
         database : _runOptions.databaseName,
 		connectionLimit: 20,
-		waitForConnections: true
+		waitForConnections: true,
+		multipleStatements:true
         /*connectTimeout: 10000 */
     });
 


### PR DESCRIPTION
Hi, 

I added functionality of creating dexter-server from Dexter Monitor UI.  It automatically creates database, starts dexter-server instance and adds entry to dexter-monitor DB. 

![image](https://cloud.githubusercontent.com/assets/13940703/20792457/13b7e72c-b7c2-11e6-9f4c-2e85608df0ff.png)

I tested on both Linux and Windows - works correctly. Also, if one have [Supervisor ](http://supervisord.org) installed, newly created server instance is automatically managed by it. 

What do you thing about it? 