### PR TITLE
Fixed #155: System.ArgumentException on opening a csproj file

### DIFF
--- a/project/dexter-vs/Dexter/Common/Core/Config/Providers/SolutionInfoProvider.cs
+++ b/project/dexter-vs/Dexter/Common/Core/Config/Providers/SolutionInfoProvider.cs
@@ -28,7 +28,7 @@ namespace Dexter.Common.Config.Providers
         {   
             Solution solution = dte.Solution;
 
-            if (solution == null || solution.Count==0)
+            if (solution == null || solution.Count==0 || string.IsNullOrEmpty(solution.FullName))
             {
                 return new ProjectInfo();
             }


### PR DESCRIPTION
I added a check whether a solution has empty name (it occurs when project is opened using .csproj file) . If so, "Analyse solution" button will be grayed out. 