### PR TITLE
Removed misstyped import

### DIFF
--- a/project/dexter-core/src/test/com/samsung/sec/dexter/core/filter/FalseAlarmConfigurationTreeTest.java
+++ b/project/dexter-core/src/test/com/samsung/sec/dexter/core/filter/FalseAlarmConfigurationTreeTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 
 import com.samsung.sec.dexter.core.config.DexterConfig;
 import com.samsung.sec.dexter.core.defect.Defect;
-import com.sun.org.apache.xml.internal.resolver.helpers.PublicId;
 
 public class FalseAlarmConfigurationTreeTest {
 


### PR DESCRIPTION
Removed "import com.sun.org.apache.xml.internal.resolver.helpers.PublicId;" which was unused and should NOT have been there at any point (probably a typo).