### PR TITLE
Update base image for Docker

### DIFF
--- a/project/dexter-server/Dockerfile
+++ b/project/dexter-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.2.1
+FROM node:8.7.0-alpine
 
 
 # Create app directory


### PR DESCRIPTION
Hi, 

I updated base image for Dexter from node:8.2.1 to node:8.7.0-alpine.
It has not only newer version of Node.js, but is also much lighter than previous one  (170.5 vs 792.3 MB).
	
I have tested container built with this updated image and did not encountered any issues. Everything works stable. 

Regards, 
Karol 
