### PR TITLE
Fix UnitTests failing while building in linux environment

### DIFF
--- a/project/dexter-metrics/src/test/com/samsung/sec/dexter/metrics/CodeMetricsGeneratorTest.java
+++ b/project/dexter-metrics/src/test/com/samsung/sec/dexter/metrics/CodeMetricsGeneratorTest.java
@@ -49,8 +49,8 @@ public class CodeMetricsGeneratorTest {
 	CodeMetrics codeMetrics = null;
 	FunctionMetrics functionMetrics = null;
 	List<String> functionList = null;
-
-	String TestDirectoryPath = "." + File.separator + File.separator +"src" + File.separator + "sample" + File.separator + "TestDirectory_For_CodeMetricsGeneratorTest";
+    
+    String TestDirectoryPath = "." + File.separator + File.separator +"src" + File.separator + "sample" + File.separator + "TestDirectory_For_CodeMetricsGeneratorTest";
     String EmptyJavaTestFilePath = "." + File.separator + File.separator +"src" + File.separator + "sample" + File.separator +"TestJavaFile_For_CodeMetricsGeneratorTest_Empty.java";
     String TooLongTestFilePath = "." + File.separator + File.separator +"src" + File.separator + "sample" + File.separator +"TestFile_For_CodeMetricsGeneratorTest_TooLong.txt";
     String LogPath = "." + File.separator + File.separator +"log" + File.separator +"dexter-core.log";

--- a/project/dexter-metrics/src/test/com/samsung/sec/dexter/metrics/CodeMetricsGeneratorTest.java
+++ b/project/dexter-metrics/src/test/com/samsung/sec/dexter/metrics/CodeMetricsGeneratorTest.java
@@ -50,11 +50,11 @@ public class CodeMetricsGeneratorTest {
 	FunctionMetrics functionMetrics = null;
 	List<String> functionList = null;
 
-	String TestDirectoryPath = ".\\src\\sample\\TestDirectory_For_CodeMetricsGeneratorTest";
-	String EmptyJavaTestFilePath = ".\\src\\sample\\TestJavaFile_For_CodeMetricsGeneratorTest_Empty.java";
-	String TooLongTestFilePath = ".\\src\\sample\\TestFile_For_CodeMetricsGeneratorTest_TooLong.txt";
-	String LogPath = ".\\log\\dexter-core.log";
-	
+	String TestDirectoryPath = "." + File.separator + File.separator +"src" + File.separator + "sample" + File.separator + "TestDirectory_For_CodeMetricsGeneratorTest";
+    String EmptyJavaTestFilePath = "." + File.separator + File.separator +"src" + File.separator + "sample" + File.separator +"TestJavaFile_For_CodeMetricsGeneratorTest_Empty.java";
+    String TooLongTestFilePath = "." + File.separator + File.separator +"src" + File.separator + "sample" + File.separator +"TestFile_For_CodeMetricsGeneratorTest_TooLong.txt";
+    String LogPath = "." + File.separator + File.separator +"log" + File.separator +"dexter-core.log";
+    
 	private boolean isDefault(CodeMetrics codeMetrics) {
 		if(!codeMetrics.getMetric("loc").equals(0)) {
 			return false;

--- a/project/dexter-metrics/src/test/com/samsung/sec/dexter/metrics/util/MetricUtilTest.java
+++ b/project/dexter-metrics/src/test/com/samsung/sec/dexter/metrics/util/MetricUtilTest.java
@@ -32,12 +32,13 @@ import org.junit.Assert;
 //import static org.junit.Assert.*;
 
 import org.junit.Test;
+import java.io.File;
 
 import com.samsung.sec.dexter.core.exception.DexterRuntimeException;
 import com.samsung.sec.dexter.metrics.util.MetricUtil;
 
 public class MetricUtilTest {
-	String TestFilePath = ".\\src\\sample\\TestFile_For_MetricUtilTest.java";
+	String TestFilePath = "." + File.separator + File.separator + "src" + File.separator+ "sample" + File.separator + "TestFile_For_MetricUtilTest.java";
 	
 	@Test
 	public void test() {
@@ -65,7 +66,7 @@ public class MetricUtilTest {
 		int start = 0;
 		int end = 10;
 		try {
-			MetricUtil.getFunctionLOCArray(".\\ThereIsNoSuchFile.no", start, end);
+			MetricUtil.getFunctionLOCArray( "." + File.separator + File.separator +"ThereIsNoSuchFile.no", start, end);
 			Assert.fail();
 		}
 		catch(DexterRuntimeException e) {


### PR DESCRIPTION
#175 
I have changed file path definition cause there are some differences between Linux&Windows path declaration that's why the bug appeared.
Now they are defined in correct way regardless of the system